### PR TITLE
Support more syntax

### DIFF
--- a/sqltree/dialect.py
+++ b/sqltree/dialect.py
@@ -59,6 +59,9 @@ class Dialect:
             self.version, start_version=start_version, end_version=end_version
         )
 
+    def get_identifier_delimiter(self) -> str:
+        return _IDENTIFIER_QUOTE[self.vendor]
+
 
 DEFAULT_DIALECT = Dialect(Vendor.mysql)
 
@@ -105,6 +108,12 @@ _FEATURES: Dict[Feature, Dict[Vendor, Union[bool, Tuple[Version, Version]]]] = {
 }
 _missing_features = set(Feature) - set(_FEATURES)
 assert not _missing_features, f"missing settings for {_missing_features}"
+
+_IDENTIFIER_QUOTE = {
+    Vendor.mysql: "`",
+    Vendor.presto: '"',
+    Vendor.redshift: '"',  # https://docs.aws.amazon.com/redshift/latest/dg/r_names.html
+}
 
 
 # from https://dev.mysql.com/doc/refman/5.7/en/keywords.html#keywords-in-current-series

--- a/sqltree/dialect.py
+++ b/sqltree/dialect.py
@@ -380,6 +380,7 @@ MYSQL8_NEW_KEYWORDS = {
 }
 # https://prestodb.io/docs/current/language/reserved.html
 PRESTO_KEYWORDS = {
+    "SET",  # not actually a keyword but otherwise we can't parse UPDATE
     "ALTER",
     "AND",
     "AS",
@@ -452,6 +453,7 @@ PRESTO_KEYWORDS = {
 }
 # https://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html
 REDSHIFT_KEYWORDS = {
+    "SET",  # not actually a keyword but otherwise we can't parse UPDATE
     "AES128",
     "AES256",
     "ALL",

--- a/sqltree/formatter.py
+++ b/sqltree/formatter.py
@@ -387,6 +387,10 @@ class Formatter(Visitor[None]):
     def visit_Placeholder(self, node: p.Placeholder) -> None:
         self.write(node.text)
 
+    def visit_PlaceholderClause(self, node: p.PlaceholderClause) -> None:
+        self.start_new_line()
+        self.visit(node.placeholder)
+
     def visit_IntegerLiteral(self, node: p.IntegerLiteral) -> None:
         self.write(str(node.value))
 

--- a/sqltree/formatter.py
+++ b/sqltree/formatter.py
@@ -183,8 +183,7 @@ class Formatter(Visitor[None]):
             self.write("FROM")
         else:
             self.visit(node.kw)
-        self.add_space()
-        self.visit(node.table)
+        self.write_comma_list(node.table)
 
     def visit_WhereClause(self, node: p.WhereClause) -> None:
         self.start_new_line()

--- a/sqltree/formatter.py
+++ b/sqltree/formatter.py
@@ -3,9 +3,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Generator, Iterator, List, Optional, Sequence, Tuple, Type
 
-from .dialect import DEFAULT_DIALECT, Dialect
-
 from . import parser as p
+from .dialect import DEFAULT_DIALECT, Dialect
 from .sqltree import sqltree
 from .tokenizer import Token
 from .visitor import Transformer, Visitor

--- a/sqltree/formatter.py
+++ b/sqltree/formatter.py
@@ -498,7 +498,7 @@ class Formatter(Visitor[None]):
             self.add_space()
             self.visit(node.for_what)
         self.visit(node.left_paren)
-        self.write_comma_list(node.index_list)
+        self.write_comma_list(node.index_list, with_space=False)
         self.visit(node.right_paren)
 
     def visit_JoinOn(self, node: p.JoinOn) -> None:
@@ -558,7 +558,11 @@ class Formatter(Visitor[None]):
             self.add_space()
             self.maybe_visit(node.as_kw, else_write="AS", add_space=True)
             self.visit(node.alias)
-        self.write_comma_list(node.index_hint_list)
+        for index_hint in node.index_hint_list:
+            self.start_new_line()
+            self.visit(index_hint.node)
+            if index_hint.trailing_comma is not None:
+                self.visit(index_hint.trailing_comma)
 
     def visit_SubQueryFactor(self, node: p.SubqueryFactor) -> None:
         self.maybe_visit(node.lateral_kw, add_space=True)
@@ -572,7 +576,7 @@ class Formatter(Visitor[None]):
 
     def visit_TableReferenceList(self, node: p.TableReferenceList) -> None:
         self.visit(node.left_paren)
-        self.write_comma_list(node.references)
+        self.write_comma_list(node.references, with_space=False)
         self.visit(node.right_paren)
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -130,6 +130,23 @@ def test_select() -> None:
     )
 
 
+def test_table_reference() -> None:
+    assert format("select x from y use index(z)") == "SELECT x\nFROM y\nUSE INDEX(z)\n"
+    assert (
+        format("select x from y use index(z), ignore key for join(z)")
+        == "SELECT x\nFROM y\nUSE INDEX(z),\nIGNORE KEY FOR JOIN(z)\n"
+    )
+    assert (
+        format("select x from y use index(z), ignore key for order by   (z)")
+        == "SELECT x\nFROM y\nUSE INDEX(z),\nIGNORE KEY FOR ORDER BY(z)\n"
+    )
+    assert format("select x from y use index()") == "SELECT x\nFROM y\nUSE INDEX()\n"
+    with pytest.raises(ParseError):
+        format("select x from y force index()")
+
+    assert format("select x from (a, b)") == "SELECT x\nFROM (a, b)\n"
+
+
 def test_update() -> None:
     assert (
         format("update x set y = default, z =3 where x=4 order   by z limit 1")

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -145,6 +145,7 @@ def test_table_reference() -> None:
         format("select x from y force index()")
 
     assert format("select x from (a, b)") == "SELECT x\nFROM (a, b)\n"
+    assert format("select x from a, b") == "SELECT x\nFROM a, b\n"
 
 
 def test_update() -> None:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -120,6 +120,14 @@ def test_select() -> None:
         format("select x from y order by z {limit}")
         == "SELECT x\nFROM y\nORDER BY z\n{limit}\n"
     )
+    assert (
+        format("select x from `y` where `select` = 3")
+        == "SELECT x\nFROM y\nWHERE `select` = 3\n"
+    )
+    assert (
+        format('select x from "y" where "select" = 3', Dialect(Vendor.redshift))
+        == 'SELECT x\nFROM y\nWHERE "select" = 3\n'
+    )
 
 
 def test_update() -> None:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -115,6 +115,11 @@ def test_select() -> None:
         LIMIT 4
         """
     )
+    assert format("select x from y {limit}") == "SELECT x\nFROM y\n{limit}\n"
+    assert (
+        format("select x from y order by z {limit}")
+        == "SELECT x\nFROM y\nORDER BY z\n{limit}\n"
+    )
 
 
 def test_update() -> None:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -147,6 +147,59 @@ def test_table_reference() -> None:
     assert format("select x from (a, b)") == "SELECT x\nFROM (a, b)\n"
     assert format("select x from a, b") == "SELECT x\nFROM a, b\n"
 
+    assert (
+        format("select x from a join b", indent=8)
+        == """
+        SELECT x
+        FROM
+            a
+        JOIN
+            b
+        """
+    )
+    assert (
+        format("select x from a join b join c", indent=8)
+        == """
+        SELECT x
+        FROM
+            a
+        JOIN
+            b
+        JOIN
+            c
+        """
+    )
+    assert (
+        format("select x from a join b on x = y join c on y = x", indent=8)
+        == """
+        SELECT x
+        FROM
+            a
+        JOIN
+            b
+        ON x = y
+        JOIN
+            c
+        ON y = x
+        """
+    )
+    assert (
+        format("select x from a join b on x = y join c on y = x and c = d", indent=8)
+        == """
+        SELECT x
+        FROM
+            a
+        JOIN
+            b
+        ON x = y
+        JOIN
+            c
+        ON
+            y = x
+            AND c = d
+        """
+    )
+
 
 def test_update() -> None:
     assert (

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -206,6 +206,16 @@ def test_insert() -> None:
         format("insert into x(a) select x from y")
         == "INSERT INTO x(a)\nSELECT x\nFROM y\n"
     )
+    assert (
+        format(
+            "insert into x(a) values(1) on duplicate key update a = values(a)", indent=8
+        )
+        == """
+        INSERT INTO x(a)
+        VALUES (1)
+        ON DUPLICATE KEY UPDATE a = VALUES(a)
+        """
+    )
 
 
 def test_replace() -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,7 +13,10 @@ def test() -> None:
         None,
         p.Keyword(T, "SELECT"),
         [p.WithTrailingComma(p.SelectExpr(p.Star(T), None, None))],
-        p.FromClause(p.Keyword(T, "FROM"), p.SimpleTableFactor(p.Identifier(T, "a"))),
+        p.FromClause(
+            p.Keyword(T, "FROM"),
+            [p.WithTrailingComma(p.SimpleTableFactor(p.Identifier(T, "a")))],
+        ),
     )
 
     tree = sqltree(
@@ -33,7 +36,10 @@ def test() -> None:
                 )
             ),
         ],
-        p.FromClause(p.Keyword(T, "FROM"), p.SimpleTableFactor(p.Identifier(T, "a"))),
+        p.FromClause(
+            p.Keyword(T, "FROM"),
+            [p.WithTrailingComma(p.SimpleTableFactor(p.Identifier(T, "a")))],
+        ),
         p.WhereClause(
             p.Keyword(T, "WHERE"),
             p.BinOp(
@@ -78,5 +84,8 @@ def test() -> None:
         None,
         p.Keyword(T, "SELECT"),
         [p.WithTrailingComma(p.SelectExpr(p.Star(T), None, None))],
-        p.FromClause(p.Keyword(T, "FROM"), p.SimpleTableFactor(p.Identifier(T, "a"))),
+        p.FromClause(
+            p.Keyword(T, "FROM"),
+            [p.WithTrailingComma(p.SimpleTableFactor(p.Identifier(T, "a")))],
+        ),
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,7 +13,7 @@ def test() -> None:
         None,
         p.Keyword(T, "SELECT"),
         [p.WithTrailingComma(p.SelectExpr(p.Star(T), None, None))],
-        p.FromClause(p.Keyword(T, "FROM"), p.Identifier(T, "a")),
+        p.FromClause(p.Keyword(T, "FROM"), p.SimpleTableFactor(p.Identifier(T, "a"))),
     )
 
     tree = sqltree(
@@ -33,7 +33,7 @@ def test() -> None:
                 )
             ),
         ],
-        p.FromClause(p.Keyword(T, "FROM"), p.Identifier(T, "a")),
+        p.FromClause(p.Keyword(T, "FROM"), p.SimpleTableFactor(p.Identifier(T, "a"))),
         p.WhereClause(
             p.Keyword(T, "WHERE"),
             p.BinOp(
@@ -78,5 +78,5 @@ def test() -> None:
         None,
         p.Keyword(T, "SELECT"),
         [p.WithTrailingComma(p.SelectExpr(p.Star(T), None, None))],
-        p.FromClause(p.Keyword(T, "FROM"), p.Identifier(T, "a")),
+        p.FromClause(p.Keyword(T, "FROM"), p.SimpleTableFactor(p.Identifier(T, "a"))),
     )


### PR DESCRIPTION
- `VALUES()` function
- Placeholders for clauses
- Joins, index hints, and other table references
- Delimited identifiers