### PR TITLE
Optimize peeking_iterator

### DIFF
--- a/sqltree/peeking_iterator.py
+++ b/sqltree/peeking_iterator.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Generic, Optional, Sequence, TypeVar
 
 T = TypeVar("T")
@@ -8,11 +8,16 @@ T = TypeVar("T")
 class PeekingIterator(Generic[T]):
     seq: Sequence[T]
     next_pos: int = 0
+    length: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.length = len(self.seq)
 
     def next(self) -> T:
-        if self.has_next():
-            self.next_pos += 1
-            return self.seq[self.next_pos - 1]
+        next_pos = self.next_pos
+        if next_pos < self.length:
+            self.next_pos = next_pos + 1
+            return self.seq[next_pos]
         raise StopIteration
 
     def __iter__(self) -> "PeekingIterator[T]":
@@ -28,7 +33,7 @@ class PeekingIterator(Generic[T]):
         self.next_pos += 1
 
     def has_next(self) -> bool:
-        return self.next_pos < len(self.seq)
+        return self.next_pos < self.length
 
     def current(self) -> T:
         return self.seq[self.next_pos - 1]
@@ -37,6 +42,6 @@ class PeekingIterator(Generic[T]):
         return self.seq[self.next_pos]
 
     def peek(self) -> Optional[T]:
-        if self.next_pos < len(self.seq):
+        if self.next_pos < self.length:
             return self.seq[self.next_pos]
         return None


### PR DESCRIPTION
Profiling shows (not surprisingly) that we spend a lot of time in
the has_next() and next() methods. A few obvious micro-optimizations:
- Inline the has_next() call in next()
- Memoize the length of the sequence instead of repeatedly calling len()
- Put self.next_pos in a local variable to avoid reading the attribute
  several times

About a 15% improvement on sqlglot's benchmarks.
