### PR TITLE
Fix table subquery

### DIFF
--- a/sqltree/formatter.py
+++ b/sqltree/formatter.py
@@ -664,7 +664,7 @@ class Formatter(Visitor[None]):
         self.maybe_visit(node.lateral_kw, add_space=True)
         self.visit(node.table_subquery)
         self.maybe_visit(node.as_kw, else_write="AS", add_space=True)
-        self.visit(node.alias)
+        self.maybe_visit(node.alias)
         if node.col_list:
             self.maybe_visit(node.left_paren, else_write="(")
             self.write_comma_list(node.col_list)
@@ -760,7 +760,11 @@ def _get_lines_for_field(
         types = {t for t in args if t is not NoneType}
     else:
         is_optional = False
-        types = {field_obj.type}
+        if isinstance(field_obj.type, str):
+            obj_type = getattr(p, field_obj.type)
+        else:
+            obj_type = field_obj.type
+        types = {obj_type}
     if (
         types
         <= {

--- a/sqltree/parser.py
+++ b/sqltree/parser.py
@@ -385,7 +385,7 @@ class SubqueryFactor(Node):
     lateral_kw: Optional[Keyword]
     table_subquery: "Subselect"
     as_kw: Optional[Keyword]
-    alias: Identifier
+    alias: Optional[Identifier]
     left_paren: Optional[Punctuation]
     col_list: Sequence[WithTrailingComma[Identifier]]
     right_paren: Optional[Punctuation]
@@ -1103,7 +1103,10 @@ def _parse_subquery_factor(
 ) -> SubqueryFactor:
     subselect = _parse_subselect(p, require_parens=True)
     as_kw = _maybe_consume_keyword(p, "AS")
-    alias = _parse_identifier(p)
+    if as_kw:
+        alias = _parse_identifier(p)
+    else:
+        alias = _maybe_parse_identifier(p)
     left_paren = _maybe_consume_punctuation(p, "(")
     if left_paren is not None:
         col_list = _parse_comma_separated(p, _parse_identifier)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -645,6 +645,45 @@ def test_table_reference() -> None:
     )
 
 
+def test_table_subquery() -> None:
+    assert format("select x from (select a from b) as a", indent=12) == """
+            SELECT x
+            FROM (
+                SELECT a
+                FROM b) AS a
+        """
+    assert format("select x from (select a from b) a", indent=12) == """
+            SELECT x
+            FROM (
+                SELECT a
+                FROM b) a
+        """
+    assert format("select x from (select a from b)", indent=12) == """
+            SELECT x
+            FROM (
+                SELECT a
+                FROM b)
+        """
+    assert format("select x from (select 1)", indent=12) == """
+            SELECT x
+            FROM (
+                SELECT 1)
+        """
+    assert format("select x from (select 1), b", indent=12) == """
+            SELECT x
+            FROM (
+                SELECT 1), b
+        """
+    assert format("select x from (select 1)join b", indent=12) == """
+            SELECT x
+            FROM
+                (
+                    SELECT 1)
+            JOIN
+                b
+        """
+
+
 def test_update() -> None:
     assert (
         format("update x set y = default, z =3 where x=4 order   by z limit 1")


### PR DESCRIPTION
fix bug: 
-Cannot format `'select a from (select a from b) as a'` 
-Cannot parse  `'select a from (select a from b)'`https://github.com/JelleZijlstra/sqltree/issues/87#issue-1699473176
